### PR TITLE
Build fix for Ubuntu 19.04: added include of sys/sysmacros.h

### DIFF
--- a/fuse-ufs/op_create.c
+++ b/fuse-ufs/op_create.c
@@ -17,6 +17,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <sys/sysmacros.h>
+
 #include "fuse-ufs.h"
 
 int do_modetoufslag (mode_t mode)


### PR DESCRIPTION
Building fails on Ubuntu 19.04:
/bin/bash ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..    -Wall -D_GNU_SOURCE  -I.. -I/usr/local/include/umview -I/usr/local/include -g -O2 -MT umfuseufs_la-op_create.lo -MD -MP -MF .deps/umfuseufs_la-op_create.Tpo -c -o umfuseufs_la-op_create.lo `test -f 'op_create.c' || echo './'`op_create.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -Wall -D_GNU_SOURCE -I.. -I/usr/local/include/umview -I/usr/local/include -g -O2 -MT umfuseufs_la-op_create.lo -MD -MP -MF .deps/umfuseufs_la-op_create.Tpo -c op_create.c  -fPIC -DPIC -o .libs/umfuseufs_la-op_create.o
op_create.c: In function ‘old_valid_dev’:
op_create.c:44:9: warning: implicit declaration of function ‘major’ [-Wimplicit-function-declaration]
  return major(dev) < 256 && minor(dev) < 256;
         ^~~~~
op_create.c:44:29: warning: implicit declaration of function ‘minor’; did you mean ‘mknod’? [-Wimplicit-function-declaration]
  return major(dev) < 256 && minor(dev) < 256;
                             ^~~~~
                             mknod
op_create.c: In function ‘new_encode_dev’:
op_create.c:54:19: error: called object ‘major’ is not a function or function pointer
  unsigned major = major(dev);
                   ^~~~~
op_create.c:54:11: note: declared here
  unsigned major = major(dev);
           ^~~~~
op_create.c:55:19: error: called object ‘minor’ is not a function or function pointer
  unsigned minor = minor(dev);
                   ^~~~~
op_create.c:55:11: note: declared here
  unsigned minor = minor(dev);
           ^~~~~

To fix this, it is necessary to include sys/sysmacros.h for minor() and major() functions.